### PR TITLE
feat: DynamoDB 중복 데이터 검색 리턴값 수정

### DIFF
--- a/src/storage.py
+++ b/src/storage.py
@@ -54,7 +54,7 @@ class DynamoDB(Storage):
             # video_id와 title을 사용하여 DynamoDB에서 항목을 조회합니다.
             response = self.storage.get_item(Key={'video_id': video_id, 'title': title})
             print('dynamo DB에서 중복 데이터 체크 성공')
-            return True
+            return 'Item' in response
         except Exception as e:
             # print(f"Error checking video in DynamoDB: {e}") # logger로 따로 처리하세요
             # return False # False를 리턴 한 이유는 중복 처리를 확인 하는거니깐 따로 처리 해 줍니다.


### PR DESCRIPTION
DynamoDB에서 데이터 검색시 response를 응답함
이때 데이터를 찾게 되면 dict 형태로 반환이 되는데 Item이라는 key 값이 포함되어 있음 그런데 찾지 못하면 Item이라는 key 값이 없는 것 같음(추측)